### PR TITLE
Remove section causing publishing error due to bug in `knitr`

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -38,25 +38,6 @@ The falcon initiative is an industry collaborative effort under pharmaverse that
 
 -   ...
 
-#### Recently Added Templates
-
-```{r, warning=FALSE, message=FALSE}
-library(slickR)
-
-tbl_imgs <- list.files(file.path("./quarto/assets/images/screenshots"), full.names = TRUE, pattern = "png")[1:3]
-tbl_links <- paste0(
-  "https://pharmaverse.github.io/falcon/quarto/table-templates/template-",
-  sapply(strsplit(tbl_imgs, "[/|.]"), `[`, 7), ".html"
-)
-
-slickR::slickR(
-  tbl_imgs,
-  objLinks = tbl_links,
-  width = "95%",
-  height = 435
-) + slickR::settings(autoplay = TRUE, dots = TRUE, adaptiveHeight = TRUE)
-```
-
 #### Contributors
 
 ::: {layout-ncol="4"}


### PR DESCRIPTION
Due to the following bug in the current version of `knitr`, the code in the Recently Added Templates section creates an error when rendering and must be temporarily removed: https://github.com/quarto-dev/quarto-cli/issues/5702